### PR TITLE
fix: Naprawa błędu AttributeError dla obiektu StudentInformation

### DIFF
--- a/custom_components/librus_apix/sensor.py
+++ b/custom_components/librus_apix/sensor.py
@@ -224,7 +224,7 @@ class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
                         (zdarzenie["data"], zdarzenie["tytul"], zdarzenie["przedmiot"])
                     )
             else:
-                uczen = student_info.get("imie_i_nazwisko", "Nieznany uczeń") if student_info else "Nieznany uczeń"
+                uczen = student_info.name if student_info else "Nieznany uczeń"
                 self._fire_events(wiadomosci, grades, uczen)
                 self._fire_homework_events(zadania, uczen)
                 self._fire_schedule_events(terminarz, uczen)


### PR DESCRIPTION
Rozwiązuje problem, w którym odświeżenie danych powodowało błąd: `'StudentInformation' object has no attribute 'get'` i sprawiało, że encje stawały się niedostępne. Wynikało to z faktu, że nowsze wersje biblioteki `librus-apix` zwracają obiekt `StudentInformation` zamiast słownika. Zmieniono przypisanie zmiennej z `.get("imie_i_nazwisko")` na bezpośrednie odwołanie do atrybutu `.name`.