### PR TITLE
fix: ogranicz liczbe ponownych logowan do jednego na cykl odswiezania

### DIFF
--- a/custom_components/librus_apix/__init__.py
+++ b/custom_components/librus_apix/__init__.py
@@ -57,9 +57,29 @@ class LibrusApiClient:
         self._client: Client = None
         self._token = None
         self._auth_lock = asyncio.Lock()
+        # Ogranicza liczbe ponownych logowan w ramach jednego cyklu odswiezania danych.
+        # Bez tego kazdy z pobieranych zasobow (oceny, wiadomosci, plan lekcji, itd.)
+        # probowalby logowac sie od nowa nawet gdy przyczyna bledu nie jest wygasly
+        # token tylko brak dostepu do danego zasobu (np. konto przedszkolaka bez
+        # dziennika ocen), co generowaloby kilkanascie zbednych logowan na cykl.
+        self._reauth_budget = 1
+
+    def start_update_cycle(self) -> None:
+        """Zresetuj limit ponownych logowan na poczatku nowego cyklu odswiezania."""
+        self._reauth_budget = 1
 
     def _reset_auth(self) -> None:
-        """Reset authentication state to force re-authentication on next call."""
+        """Reset authentication state to force re-authentication on next call.
+
+        Ograniczone do jednego dodatkowego logowania na cykl odswiezania - patrz
+        `_reauth_budget`.
+        """
+        if self._reauth_budget <= 0:
+            _LOGGER.debug(
+                "Limit ponownych logowan w tym cyklu wyczerpany - pomijanie kolejnej autoryzacji"
+            )
+            return
+        self._reauth_budget -= 1
         self._client = None
         self._token = None
 


### PR DESCRIPTION
## Problem

Kazda z metod sync_get_* (oceny, wiadomosci, zadania, plan lekcji, frekwencja, ogloszenia, info o uczniu) probowala ponownie sie zalogowac niezaleznie po TokenError. Biblioteka librus_apix zglasza ten sam wyjatek zarowno przy realnie wygaslym tokenie, jak i gdy Librus zwraca strone 'Brak dostepu' (np. konto bez dostepu do danego modulu dziennika, jak konto przedszkolaka). W efekcie kazdy z 8 zasobow niezaleznie probowal sie zalogowac ponownie, generujac nawet **~16 logowan w jednym cyklu odswiezania** (co ~5 minut), co zwieksza ryzyko zablokowania konta przez Librus za podejrzana liczbe logowan.

## Rozwiazanie

- Dodano LibrusApiClient.start_update_cycle() wywolywane raz na poczatku kazdego cyklu odswiezania danych koordynatora.
- Dodano limit _reauth_budget, ktory pozwala na najwyzej jedno dodatkowe (ponowne) logowanie na caly cykl - kolejne wywolania _reset_auth() w tym samym cyklu sa pomijane (z logiem debug), zamiast wymuszac kolejne logowanie.

Redukuje to liczbe logowan z ~16 do 1-2 na cykl w scenariuszu, gdy zasob jest trwale niedostepny dla danego konta.